### PR TITLE
Update main.py to format news articles as clickable HTML links

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,14 +45,8 @@ def get_news(topic, from_date, to_date, language='en', api_key=api_key, content=
     
     #print("content is: ", content)
     for article in articles:
-        print("> ", article['title'])
-        content = content + "> " + article['title'] + "\n"
-        print("   ", article['url'])
-        content = content + "  " + article['url'] + "\n"
+        content += f"<a href='{article['url']}'>{article['title']}</a><br>\n"
     #print("content is now: ", content)
-
-    #for i in range(len(content['articles'])):
-    #    print('> ', content['articles'][i]['title'])
 
     return content
         
@@ -156,7 +150,7 @@ print("content is: ", content)
 
 ### send email ###
 yag = yagmail.SMTP(sender,email_password )                      # create an instance of the SMTP object isntance using the SMTP class
-yag.send(to=receiver, subject=subject, contents=content)
+yag.send(to=receiver, subject=subject, contents=content, subtype='html')  # Set email content type to HTML
 print("email sent")
 
 """


### PR DESCRIPTION
Updates `main.py` to format news articles as clickable HTML links in the email content and ensures the email content type is set to HTML.

- Modifies the `get_news` function to format news articles as clickable HTML links using anchor tags, enhancing the readability and accessibility of the news content in the email.
- Sets the email content type to HTML by adding the `subtype='html'` parameter to the `yag.send` function call, ensuring that the email client renders the links correctly.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/my_daily_news?shareId=5c192cb2-b8f7-4346-b6ba-3bf47671b33c).